### PR TITLE
Retrieve Golang install from go.dev and always use latest stable release.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ARG LIBTOOL_VERSION="2.4.6_1"
 ARG LIBTOOL_BASEURL="https://github.com/neilotoole/xcgo/releases/download/v0.1"
 ARG GOLANGCI_LINT_VERSION="1.42.1"
 ARG GORELEASER_VERSION="0.182.1"
-ARG GO_VERSION="1.17"
+ARG GO_VERSION=""
 ARG UBUNTU=bionic
 
 
@@ -95,10 +95,13 @@ RUN mkdir -p "${GOPATH}/src"
 
 # As suggested here: https://github.com/golang/go/wiki/Ubuntu
 RUN add-apt-repository -y ppa:longsleep/golang-backports
-RUN apt update && apt install -y golang-${GO_VERSION}
-RUN ln -s /usr/lib/go-${GO_VERSION} /usr/lib/go
-RUN ln -s /usr/lib/go/bin/go /usr/bin/go
-RUN ln -s /usr/lib/go/bin/gofmt /usr/bin/gofmt
+RUN if test -z "${GO_VERSION}"; then GO_VERSION=$(curl 'https://go.dev/VERSION?m=text'); fi && \
+	curl -L -o go.tar.gz https://go.dev/dl/${GO_VERSION}.linux-amd64.tar.gz && \
+	rm -rf /usr/local/go && tar -C /usr/local -xzf go.tar.gz && \
+	rm go.tar.gz
+RUN ln -s /usr/local/go /usr/lib/go
+RUN ln -s /usr/local/go/bin/go /usr/bin/go
+RUN ln -s /usr/local/go/bin/gofmt /usr/bin/gofmt
 
 RUN go version
 


### PR DESCRIPTION
This allows the container to be built with versions of go that are not included in the package manager.
    
When GO_VERSION is not specified the latest stable version is retrieved. Previously the major version defaulted to 1.17, this is still the case but the Dockerfile no longer needs to be updated when a newer major stable version is released. This change is primarily to avoid hardcoding the minor version as a default, the download URLs at go.dev use the full release version. You could probably figure out the latest minor version and have GO_VERSION represent the major version but this seems a bit simpler provided there's no objections with the change.

go1.18beta1 can be built with the following now:

```
docker build --build-arg GO_VERSION=go1.18beta1 -t xcgo .
```