### PR TITLE
Build fixes for building with Ubuntu Jammy (22.04 LTS)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,19 +41,19 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y \
 # unpack it in the proper place.
 RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core' | jq '.download_url' -r) --output core.snap
 RUN mkdir -p /snap/core
-RUN unsquashfs -d /snap/core/current core.snap
+RUN unsquashfs -no-exit-code -d /snap/core/current core.snap
 
 # Grab the core18 snap (which snapcraft uses as a base) from the stable channel
 # and unpack it in the proper place.
 RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core18' | jq '.download_url' -r) --output core18.snap
 RUN mkdir -p /snap/core18
-RUN unsquashfs -d /snap/core18/current core18.snap
+RUN unsquashfs -no-exit-code -d /snap/core18/current core18.snap
 
 # Grab the snapcraft snap from the stable channel and unpack it in the proper
 # place.
 RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/snapcraft?channel=stable' | jq '.download_url' -r) --output snapcraft.snap
 RUN mkdir -p /snap/snapcraft
-RUN unsquashfs -d /snap/snapcraft/current snapcraft.snap
+RUN unsquashfs -no-exit-code -d /snap/snapcraft/current snapcraft.snap
 
 # Create a snapcraft runner
 RUN mkdir -p /snap/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ ARG UBUNTU
 # want ubuntu:bionic (some things we want, e.g. go1.14, don't have good
 # packages for xenial at the time of writing).
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 # This section lifted from snapcore/snapcraft:stable
 # Grab dependencies
 RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y \
@@ -111,6 +113,8 @@ FROM golangcore AS devtools
 # Dependencies for https://github.com/tpoechtrager/osxcross and some
 # other stuff.
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     clang \
@@ -176,6 +180,9 @@ WORKDIR /root
 
 ####################  docker  ####################
 FROM osx-cross AS docker
+
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
     apt-transport-https \
     ca-certificates \


### PR DESCRIPTION
This is a quick and ugly hack to get an image with security fixes.

- Disable interaction, seen when trying to build with UBUNTU=focal
- Don't exit on squashfs non-fatal errors, seen with UBUNTU=jammy

With both changes I could build an image with:

```
podman build --build-arg GO_VERSION=go1.24.2 --build-arg UBUNTU=jammy .
```

